### PR TITLE
Fixed a bug where focusing a file focuses all files with the same name

### DIFF
--- a/src/main/appWindow.ts
+++ b/src/main/appWindow.ts
@@ -132,36 +132,39 @@ let firstTime = true;
 function buildTree(dir: string, root: any) {
   const stats = fs.statSync(dir);
   let name = path.basename(dir).split('.')[0];
+  let key = dir;
 
   if (firstTime) {
     name = 'root';
+    key = 'root';
     firstTime = false;
   }
 
   if (!stats.isDirectory()) {
-    root[name] = {
-      index: name,
+    root[key] = {
+      index: key,
       data: name,
       children: [],
       path: dir,
       isFolder: false,
     };
-    return name;
+
+    return key;
   }
 
   const children = fs
     .readdirSync(dir)
     .map((child) => buildTree(path.join(dir, child), root));
 
-  root[name] = {
-    index: name,
+  root[key] = {
+    index: key,
     isFolder: true,
     data: name,
     children,
     path: dir,
   };
 
-  return name;
+  return key;
 }
 
 ipcMain.on('getNotebooks', () => {


### PR DESCRIPTION
I fixed the bug states in issue #6 where focusing a file focuses all files with the same name.

The problem was that it always assigns the same key (`name`) to each file or directory, regardless of their actual name or path. This means that if there are multiple files or directories with the same name, they will overwrite each other in the root object, because they are assigned the same key.

To fix that, I assigned each file a new key based on their path (which is unique).