### PR TITLE
Fixed several bugs (including #4)

### DIFF
--- a/src/renderer/components/FilesSidebar/FileSystem.tsx
+++ b/src/renderer/components/FilesSidebar/FileSystem.tsx
@@ -16,17 +16,18 @@ import {
   updateItemsPosition,
   changeItemPath,
   generateStateWithNewFolder,
-  newFolderKey,
+  newFolderName,
   generateStateWithNewFile,
-  newFileKey,
+  newFileName,
+  checkIfItemNameIsFolder,
 } from './FileSystemHelpers';
 import { MathTreeItem, TreeItemsObj } from './types';
 import { useTranslation } from 'react-i18next';
 
-type receivedProps = {filesPath: string, root: SetStateAction<TreeItemsObj>}
+type receivedProps = { filesPath: string; root: SetStateAction<TreeItemsObj> };
 declare global {
   interface Window {
-      api: any;
+    api: any;
   }
 }
 function FileSystem() {
@@ -71,8 +72,8 @@ function FileSystem() {
 
   const addFolder = () => {
     //Todo: check also that they are in the same folder - compare paths
-    if (items[newFolderKey]?.isFolder) {
-      setErrorModalContent(t("Modal 3"));
+    if (checkIfItemNameIsFolder(newFileName, items)) {
+      setErrorModalContent(t('Modal 3'));
       setErrorModalOpen(true);
       return;
     }
@@ -81,8 +82,8 @@ function FileSystem() {
 
   const addFile = () => {
     //Todo: check also that they are in the same folder - compare paths
-    if (items[newFileKey]?.isFolder == false) {
-      setErrorModalContent(t("Modal 2"));
+    if (checkIfItemNameIsFolder(newFileName, items) == false) {
+      setErrorModalContent(t('Modal 2'));
       setErrorModalOpen(true);
       return;
     }
@@ -91,7 +92,7 @@ function FileSystem() {
 
   const handleRenameItem = (item: MathTreeItem, name: string): void => {
     if (items[name]) {
-      setErrorModalContent(t("Modal 4"));
+      setErrorModalContent(t('Modal 4'));
       setErrorModalOpen(true);
     } else {
       let newPath: string;
@@ -144,17 +145,17 @@ function FileSystem() {
     <div className='file-system'>
       <div className='file-system-header'>
         <span
-          data-tooltip={t("Notebooks Tooltip")}
+          data-tooltip={t('Notebooks Tooltip')}
           className='file-system-header-title'
           onDoubleClick={() => window.api.openFiles()}
         >
-          {t("My Notebooks")}
+          {t('My Notebooks')}
         </span>
         <div className='file-system-header-buttons'>
-          <button onClick={addFolder} data-tooltip={t("New Folder")}>
+          <button onClick={addFolder} data-tooltip={t('New Folder')}>
             <i className='fi fi-rr-add-folder' />
           </button>
-          <button onClick={addFile} data-tooltip={t("New File")}>
+          <button onClick={addFile} data-tooltip={t('New File')}>
             <i className='fi-rr-add-document' />
           </button>
         </div>

--- a/src/renderer/components/FilesSidebar/FileSystem.tsx
+++ b/src/renderer/components/FilesSidebar/FileSystem.tsx
@@ -72,7 +72,7 @@ function FileSystem() {
 
   const addFolder = () => {
     //Todo: check also that they are in the same folder - compare paths
-    if (checkIfItemNameIsFolder(newFileName, items)) {
+    if (checkIfItemNameIsFolder(newFolderName, focusedItem, items)) {
       setErrorModalContent(t('Modal 3'));
       setErrorModalOpen(true);
       return;
@@ -82,7 +82,7 @@ function FileSystem() {
 
   const addFile = () => {
     //Todo: check also that they are in the same folder - compare paths
-    if (checkIfItemNameIsFolder(newFileName, items) == false) {
+    if (checkIfItemNameIsFolder(newFileName, focusedItem, items) == false) {
       setErrorModalContent(t('Modal 2'));
       setErrorModalOpen(true);
       return;

--- a/src/renderer/components/FilesSidebar/FileSystem.tsx
+++ b/src/renderer/components/FilesSidebar/FileSystem.tsx
@@ -19,7 +19,7 @@ import {
   newFolderName,
   generateStateWithNewFile,
   newFileName,
-  checkIfItemNameIsFolder,
+  itemExistsInParent,
 } from './FileSystemHelpers';
 import { MathTreeItem, TreeItemsObj } from './types';
 import { useTranslation } from 'react-i18next';
@@ -36,9 +36,11 @@ function FileSystem() {
 
   const [errorModalContent, setErrorModalContent] = useState('');
   const [errorModalOpen, setErrorModalOpen] = useState(false);
-  const [focusedItem, setFocusedItem] = useState<TreeItemIndex>(-1);
+  const [focusedDirectory, setFocusedDirectory] =
+    useState<TreeItemIndex>('root');
   const [expandedItems, setExpandedItems] = useState([]);
   const [selectedItems, setSelectedItems] = useState([]);
+  const [selectedFolder, setSelectedFolder] = useState<TreeItemIndex>(-1);
 
   const [items, setItems] = useState<TreeItemsObj>({
     root: {
@@ -71,23 +73,21 @@ function FileSystem() {
   };
 
   const addFolder = () => {
-    //Todo: check also that they are in the same folder - compare paths
-    if (checkIfItemNameIsFolder(newFolderName, focusedItem, items)) {
+    if (itemExistsInParent(newFolderName, focusedDirectory, items, true)) {
       setErrorModalContent(t('Modal 3'));
       setErrorModalOpen(true);
       return;
     }
-    setItems((prev) => generateStateWithNewFolder(prev, focusedItem));
+    setItems((prev) => generateStateWithNewFolder(prev, focusedDirectory));
   };
 
   const addFile = () => {
-    //Todo: check also that they are in the same folder - compare paths
-    if (checkIfItemNameIsFolder(newFileName, focusedItem, items) == false) {
+    if (itemExistsInParent(newFileName, focusedDirectory, items, false)) {
       setErrorModalContent(t('Modal 2'));
       setErrorModalOpen(true);
       return;
     }
-    setItems((prev) => generateStateWithNewFile(prev, focusedItem));
+    setItems((prev) => generateStateWithNewFile(prev, focusedDirectory));
   };
 
   const handleRenameItem = (item: MathTreeItem, name: string): void => {
@@ -171,7 +171,7 @@ function FileSystem() {
           getItemTitle={(item) => item.data}
           viewState={{
             ['tree-2']: {
-              focusedItem,
+              focusedItem: selectedFolder,
               expandedItems,
               selectedItems,
             },
@@ -179,8 +179,10 @@ function FileSystem() {
           onDrop={handleOnDrop}
           onFocusItem={(item) => {
             const mathTreeItem = item as MathTreeItem;
-            setFocusedItem(mathTreeItem.index);
-            if (!item.isFolder) setSelectedFile(mathTreeItem.path);
+            setSelectedFolder(mathTreeItem.index);
+            item.isFolder
+              ? setFocusedDirectory(mathTreeItem.index)
+              : setSelectedFile(mathTreeItem.path);
           }}
           onExpandItem={(item) =>
             setExpandedItems([...expandedItems, item.index])

--- a/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
+++ b/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
@@ -181,11 +181,14 @@ export const generateStateWithNewFile = (
   return newState;
 };
 
-export const checkIfItemNameIsFolder = (name: string, items: TreeItemsObj) => {
-  for (const [, value] of Object.entries(items)) {
-    const mathTreeItem = value as MathTreeItem;
-    if (mathTreeItem.data == name) {
-      return mathTreeItem.isFolder;
+export const checkIfItemNameIsFolder = (
+  name: string,
+  parent: TreeItemIndex,
+  items: TreeItemsObj,
+) => {
+  for (const [key, value] of Object.entries(items)) {
+    if (key === parent) {
+      return value.children.includes(name);
     }
   }
 };

--- a/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
+++ b/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
@@ -106,7 +106,7 @@ export const generateStateWithNewFolder = (
   let parentValue;
   let parentKey;
 
-  if (parentIndex != -1) {
+  if (parentIndex != 'root') {
     parentValue = prev[parentIndex];
     parentKey = parentIndex;
   } else {
@@ -171,18 +171,6 @@ export const generateStateWithNewFile = (
 
   return newState;
 };
-
-// export const checkIfItemNameIsFolder = (
-//   name: string,
-//   parent: TreeItemIndex,
-//   items: TreeItemsObj,
-// ) => {
-//   for (const [key, value] of Object.entries(items)) {
-//     if (key === parent) {
-//       return value.children.includes(name);
-//     }
-//   }
-// };
 
 export function itemExistsInParent(
   name: string,

--- a/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
+++ b/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
@@ -17,7 +17,9 @@ export const draggedToTheSameParent = (
   if (prev[target.parentItem].data != 'root') {
     draggedToSameParent = prev[target.parentItem].children.includes(item.index);
   } else if ((target as DraggingPositionItem).targetItem == 'root') {
-    draggedToSameParent = prev[(target as DraggingPositionItem).targetItem].children.includes(item.index);
+    draggedToSameParent = prev[
+      (target as DraggingPositionItem).targetItem
+    ].children.includes(item.index);
   }
   return draggedToSameParent;
 };
@@ -38,7 +40,7 @@ export const addItemToNewParent = (
       item,
       prev[target.parentItem].path +
         '\\' +
-        item.index +
+        item.data +
         (item.isFolder ? '' : '.json'),
     );
   } else {
@@ -48,7 +50,7 @@ export const addItemToNewParent = (
         item,
         prev[target.targetItem].path +
           '\\' +
-          item.index +
+          item.data +
           (item.isFolder ? '' : '.json'),
       );
     } else {
@@ -61,7 +63,7 @@ export const addItemToNewParent = (
             item,
             mathTreeItem.path +
               '\\' +
-              item.index +
+              item.data +
               (item.isFolder ? '' : '.json'),
           );
         }
@@ -95,7 +97,7 @@ export const deleteItemFromItsPreviousParent = (
   }
 };
 
-export const newFolderKey = 'New Folder';
+export const newFolderName = 'New Folder';
 
 export const generateStateWithNewFolder = (
   prev: TreeItemsObj,
@@ -104,7 +106,7 @@ export const generateStateWithNewFolder = (
   let parentValue;
   let parentKey;
 
-  if (focusedItem) {
+  if (focusedItem != -1) {
     for (const [key, value] of Object.entries(prev)) {
       const mathTreeItem = value as MathTreeItem;
       if (mathTreeItem.children.includes(focusedItem)) {
@@ -117,15 +119,15 @@ export const generateStateWithNewFolder = (
     parentKey = 'root';
   }
 
-  parentValue.children.push(newFolderKey);
+  const newFolderPath = parentValue.path + '\\' + newFolderName;
+  parentValue.children.push(newFolderPath);
 
-  const newFolderPath = parentValue.path + '\\' + newFolderKey;
   const newState = {
     ...prev,
     [parentKey]: parentValue,
-    [newFolderKey]: {
-      index: newFolderKey,
-      data: newFolderKey,
+    [newFolderPath]: {
+      index: newFolderPath,
+      data: newFolderName,
       children: [] as TreeItemIndex[],
       path: newFolderPath,
       isFolder: true,
@@ -137,7 +139,7 @@ export const generateStateWithNewFolder = (
   return newState;
 };
 
-export const newFileKey = 'New File';
+export const newFileName = 'New File';
 
 export const generateStateWithNewFile = (
   prev: TreeItemsObj,
@@ -146,7 +148,7 @@ export const generateStateWithNewFile = (
   let parentValue;
   let parentKey;
 
-  if (focusedItem) {
+  if (focusedItem != -1) {
     for (const [key, value] of Object.entries(prev)) {
       const mathTreeItem = value as MathTreeItem;
       if (mathTreeItem.children.includes(focusedItem)) {
@@ -159,16 +161,16 @@ export const generateStateWithNewFile = (
     parentKey = 'root';
   }
 
-  parentValue.children.push(newFileKey);
+  const newFilePath = parentValue.path + '\\' + newFileName + '.json';
+  parentValue.children.push(newFilePath);
 
-  const newFilePath = parentValue.path + '\\' + newFileKey + '.json';
   const newState = {
     ...prev,
     [parentKey]: parentValue,
-    [newFileKey]: {
-      index: newFileKey,
-      data: newFileKey,
-      children: ([] as Array<any>),
+    [newFilePath]: {
+      index: newFilePath,
+      data: newFileName,
+      children: [] as Array<any>,
       path: newFilePath,
       isFolder: false,
     },
@@ -177,4 +179,13 @@ export const generateStateWithNewFile = (
   window.api.newFile(newFilePath);
 
   return newState;
+};
+
+export const checkIfItemNameIsFolder = (name: string, items: TreeItemsObj) => {
+  for (const [, value] of Object.entries(items)) {
+    const mathTreeItem = value as MathTreeItem;
+    if (mathTreeItem.data == name) {
+      return mathTreeItem.isFolder;
+    }
+  }
 };

--- a/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
+++ b/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
@@ -101,19 +101,14 @@ export const newFolderName = 'New Folder';
 
 export const generateStateWithNewFolder = (
   prev: TreeItemsObj,
-  focusedItem: TreeItemIndex,
+  parentIndex: TreeItemIndex,
 ) => {
   let parentValue;
   let parentKey;
 
-  if (focusedItem != -1) {
-    for (const [key, value] of Object.entries(prev)) {
-      const mathTreeItem = value as MathTreeItem;
-      if (mathTreeItem.children.includes(focusedItem)) {
-        parentValue = mathTreeItem;
-        parentKey = key;
-      }
-    }
+  if (parentIndex != -1) {
+    parentValue = prev[parentIndex];
+    parentKey = parentIndex;
   } else {
     parentValue = prev['root'];
     parentKey = 'root';
@@ -143,24 +138,20 @@ export const newFileName = 'New File';
 
 export const generateStateWithNewFile = (
   prev: TreeItemsObj,
-  focusedItem: TreeItemIndex,
+  parentIndex: TreeItemIndex,
 ) => {
   let parentValue;
   let parentKey;
 
-  if (focusedItem != -1) {
-    for (const [key, value] of Object.entries(prev)) {
-      const mathTreeItem = value as MathTreeItem;
-      if (mathTreeItem.children.includes(focusedItem)) {
-        parentValue = mathTreeItem;
-        parentKey = key;
-      }
-    }
+  if (parentIndex != 'root') {
+    parentValue = prev[parentIndex];
+    parentKey = parentIndex;
   } else {
     parentValue = prev['root'];
     parentKey = 'root';
   }
 
+  // TODO: format \\ and / correctly
   const newFilePath = parentValue.path + '\\' + newFileName + '.json';
   parentValue.children.push(newFilePath);
 
@@ -181,14 +172,37 @@ export const generateStateWithNewFile = (
   return newState;
 };
 
-export const checkIfItemNameIsFolder = (
+// export const checkIfItemNameIsFolder = (
+//   name: string,
+//   parent: TreeItemIndex,
+//   items: TreeItemsObj,
+// ) => {
+//   for (const [key, value] of Object.entries(items)) {
+//     if (key === parent) {
+//       return value.children.includes(name);
+//     }
+//   }
+// };
+
+export function itemExistsInParent(
   name: string,
   parent: TreeItemIndex,
   items: TreeItemsObj,
-) => {
-  for (const [key, value] of Object.entries(items)) {
-    if (key === parent) {
-      return value.children.includes(name);
+  folder: boolean,
+): boolean {
+  const parentItem = items[parent];
+  if (!parentItem || !parentItem.children) {
+    return false; // the parent directory does not exist or is not a folder
+  }
+
+  for (const childIndex of parentItem.children) {
+    const childItem = items[childIndex];
+    // TODO: format \\ and / correctly
+    if (childItem.path.split('\\').pop().split('.')[0] === name) {
+      // if the name matches, check if the item is a folder or a file
+      return folder ? childItem.isFolder === true : !childItem.isFolder;
     }
   }
-};
+
+  return false; // did not find a matching item
+}


### PR DESCRIPTION
I have fixed several bugs in this Pull Request.

Firstly, I addressed issue #4. I fixed it by doing something similar to what @alex-laycalvert suggested there.
I changed `if(focusedItem)` to `if(focusedItem != -1)` in `generateStateWithNewFolder` and `generateStateWithNewFolder` (located in `FileSystemHelpers.ts`). In my opinion, this change is more accurate because `item.index` will either be `-1` or a string. Using `if(focusedItem >= 0)` would work but is less clear.

Secondly, I addressed some bugs related to PR #22 regarding focusing a file. Since in that PR I changed the structure of the file system item (making the index and the object key the path of the file) it broke some stuff:
- It broke dragging and dropping files. I fixed it by adapting the new changes in the helper functions (inside `FileSystemHelpers.ts`)
- In `addFile` and `addFolder` functions (located in `FileSystem.tsx`), the check for the existence of an item was broken because the key is no longer the name but the path. I implemented a new function in `FileSystemHelpers.tsx` to make this check, now that the name is a property (`data`) and not the object key.

**_Important note: I have not yet adapted the `handleRenameItem` function (located in `FileSystem.tsx`) to the changes in PR #22. Therefore, renaming will likely be broken when it is implemented. I will make sure to fix it as soon as possible._**

I believe these changes have resolved all known issues. However, if any further bugs are discovered, I will be sure to fix them as soon as possible.