### PR TITLE
feat: rename and delete items

### DIFF
--- a/misc/window/windowPreload.ts
+++ b/misc/window/windowPreload.ts
@@ -45,8 +45,8 @@ contextBridge.exposeInMainWorld('api', {
   getNotebooks: () => {
     ipcRenderer.send('getNotebooks');
   },
-  delete: (file: string) => {
-    ipcRenderer.send('delete', file);
+  delete: (path: string, isFolder: boolean) => {
+    ipcRenderer.send('delete', path, isFolder);
   },
   newFile: (filePath: string) => {
     ipcRenderer.send('newFile', filePath);
@@ -69,7 +69,7 @@ contextBridge.exposeInMainWorld('api', {
   saveX: (data: string, filePath: string) => {
     ipcRenderer.send('saveX', data, filePath);
   },
-  loadX: (filePath:string) => {
+  loadX: (filePath: string) => {
     ipcRenderer.send('loadX',filePath);
   },
   getOS: () => {

--- a/src/common/locals/en.ts
+++ b/src/common/locals/en.ts
@@ -51,4 +51,7 @@ export const EN_TRANSLATION = {
   Saved: 'File saved!',
   'Save Error': 'Error while saving file',
   'Text Placeholder': 'Insert text...',
+  Click: 'Click',
+  'Delete Item': 'on item to delete it',
+  'Rename Item': 'on item to rename it',
 };

--- a/src/main/appWindow.ts
+++ b/src/main/appWindow.ts
@@ -112,6 +112,10 @@ ipcMain.on('move', (event, oldDir, newDir) => {
   fs.renameSync(oldDir, newDir);
 });
 
+ipcMain.on('delete', (event, path, isFolder) => {
+  isFolder ? fs.rmSync(path, { recursive: true, force: true }) : fs.rmSync(path);
+});
+
 ipcMain.on('load', (event, file) => {
   fs.readFile(file, 'utf-8', (error, data) => {
     appWindow.webContents.send('fromMain', data);

--- a/src/renderer/components/FilesSidebar/FileSystem.scss
+++ b/src/renderer/components/FilesSidebar/FileSystem.scss
@@ -99,9 +99,8 @@
   }
 
   .files-tree-container {
-    height: 100%;
     width: 100%;
-    flex-grow: 1;
+    
     min-width: inherit;
     max-width: inherit;
 
@@ -243,6 +242,16 @@
             }
           }
         }
+      }
+    }
+
+    .instruction-p {
+      color: hsla(var(--app-text-color), 0.6);
+      font-size: smaller;
+      .button-text {
+        background-color: var(--selected-bgcolor);
+        padding: 2px 6px;
+        border-radius: 15px;
       }
     }
   }

--- a/src/renderer/components/FilesSidebar/FileSystem.tsx
+++ b/src/renderer/components/FilesSidebar/FileSystem.tsx
@@ -9,7 +9,6 @@ import {
   TreeItem,
   DraggingPositionBetweenItems,
   TreeItemIndex,
-  DraggingPosition,
 } from 'react-complex-tree';
 import './FileSystem.scss';
 import {
@@ -33,7 +32,7 @@ declare global {
   }
 }
 function FileSystem() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { setSelectedFile } = useGeneralContext();
 
   const [errorModalContent, setErrorModalContent] = useState('');
@@ -204,7 +203,7 @@ function FileSystem() {
           canDropOnNonFolder={true}
           getItemTitle={(item) => item.data}
           viewState={{
-            ['tree-2']: {
+            ['fileSystem']: {
               focusedItem,
               expandedItems,
               selectedItems,
@@ -231,7 +230,17 @@ function FileSystem() {
           onSelectItems={setSelectedItems}
           onRenameItem={handleRenameItem}
         >
-          <Tree treeId='tree-2' rootItem='root' treeLabel='Tree Example' />
+          <Tree treeId='fileSystem' rootItem='root' treeLabel='File System' />
+          <div>
+            <p className='instruction-p'>
+              {t('Click')} <span className='button-text'>Delete</span>{' '}
+              {t('Delete Item')}
+            </p>
+            <p className='instruction-p'>
+              {t('Click')} <span className='button-text'>R</span>{' '}
+              {t('Rename Item')}
+            </p>
+          </div>
         </ControlledTreeEnvironment>
       </div>
       <ErrorModal open={errorModalOpen} onClose={handleErrorModalClose}>

--- a/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
+++ b/src/renderer/components/FilesSidebar/FileSystemHelpers.ts
@@ -14,24 +14,30 @@ export const draggedToTheSameParent = (
 ): boolean => {
   let draggedToSameParent;
 
-  if (prev[target.parentItem].data != 'root') {
-    const idx = 'targetItem' in target ? target.targetItem : target.parentItem;
-    draggedToSameParent = prev[idx].children.includes(item.index);
-  } else if ('targetItem' in target && target.targetItem == 'root') {
-    draggedToSameParent = prev[
-      (target as DraggingPositionItem).targetItem
-    ].children.includes(item.index);
-  } else if (target.parentItem == 'root') {
-    draggedToSameParent = prev[
-      (target as DraggingPositionItem).parentItem
-    ].children.includes(item.index);
+  if (target.targetType === "item" && prev[target.targetItem].isFolder) {
+    draggedToSameParent = prev[target.targetItem].children.includes(item.index);
+  } else {
+    draggedToSameParent = prev[target.parentItem].children.includes(item.index);
   }
+
   return draggedToSameParent;
 };
 
-export const changeItemPath = (item: MathTreeItem, newPath: string) => {
-  window.api.move(item.path, newPath);
-  item.path = newPath;
+export const changeItemPath = (prev: TreeItemsObj, item: MathTreeItem, newPath: string) => { 
+  const oldPath = item.path;
+
+  window.api.move(oldPath, newPath)
+
+  const { [oldPath]: _, ...rest } = prev;
+  
+  prev = {
+    ...rest,
+    [newPath]: {
+      ...item,
+      index: newPath,
+      path: newPath,
+    },
+  }
 };
 
 export const addItemToNewParent = (
@@ -42,6 +48,7 @@ export const addItemToNewParent = (
   if (target.targetType != 'item') {
     prev[target.parentItem].children.push(item.index);
     changeItemPath(
+      prev,
       item,
       prev[target.parentItem].path +
         '\\' +
@@ -52,6 +59,7 @@ export const addItemToNewParent = (
     if (prev[target.targetItem].isFolder) {
       prev[target.targetItem].children.push(item.index);
       changeItemPath(
+        prev,
         item,
         prev[target.targetItem].path +
           '\\' +
@@ -65,6 +73,7 @@ export const addItemToNewParent = (
         if (mathTreeItem.children.includes(target.targetItem)) {
           mathTreeItem.children.push(item.index);
           changeItemPath(
+            prev,
             item,
             mathTreeItem.path +
               '\\' +


### PR DESCRIPTION
I have added options to delete and rename items using keybinds. You can now use the `Delete` key to delete items and the `R` key to rename them. However, there is one bug that I haven't been able to fix with the rename functionality. In `handleRenameItem`, the `setItems` state updating function doesn't update the state for some reason. I have checked the code, and everything seems fine. Looking for help on that.

I will soon add UI buttons to perform these actions, in addition to the keybinds.